### PR TITLE
refactor(services): remove json parsing from ApiRequest responses

### DIFF
--- a/src/Services/CategoryService.php
+++ b/src/Services/CategoryService.php
@@ -2,7 +2,6 @@
 
 namespace Zdearo\Meli\Services;
 
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -20,8 +19,7 @@ class CategoryService
     public function getSites(): array
     {
         return ApiRequest::get('sites')
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -35,8 +33,7 @@ class CategoryService
     public function getCategories(string $siteId): array
     {
         return ApiRequest::get("sites/{$siteId}/categories")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -50,8 +47,7 @@ class CategoryService
     public function get(string $categoryId): array
     {
         return ApiRequest::get("categories/{$categoryId}")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -65,8 +61,7 @@ class CategoryService
     public function getAttributes(string $categoryId): array
     {
         return ApiRequest::get("categories/{$categoryId}/attributes")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -80,8 +75,7 @@ class CategoryService
     public function getListingExposures(string $siteId): array
     {
         return ApiRequest::get("sites/{$siteId}/listing_exposures")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -97,8 +91,7 @@ class CategoryService
     {
         return ApiRequest::get("sites/{$siteId}/listing_prices")
             ->withQuery(['price' => $price])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -120,7 +113,8 @@ class CategoryService
             $request->withQuery(['limit' => $limit]);
         }
 
-        return $request->send()->json();
+        return $request
+            ->send();
     }
 
     /**
@@ -134,8 +128,7 @@ class CategoryService
     public function getClassifiedsPromotionPacks(string $categoryId): array
     {
         return ApiRequest::get("categories/{$categoryId}/classifieds_promotion_packs")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -149,7 +142,6 @@ class CategoryService
     public function getDomainTechnicalSpecs(string $domainId): array
     {
         return ApiRequest::get("domains/{$domainId}/technical_specs")
-            ->send()
-            ->json();
+            ->send();
     }
 }

--- a/src/Services/NotificationService.php
+++ b/src/Services/NotificationService.php
@@ -2,7 +2,6 @@
 
 namespace Zdearo\Meli\Services;
 
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -22,11 +21,10 @@ class NotificationService
     public function getMissedFeeds(int $appId, array $filters = []): array
     {
         $filters['app_id'] = $appId;
-        
+
         return ApiRequest::get('missed_feeds')
             ->withQuery($filters)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -42,6 +40,7 @@ class NotificationService
     public function getMissedFeedsByTopic(int $appId, string $topic, array $filters = []): array
     {
         $filters['topic'] = $topic;
+
         return $this->getMissedFeeds($appId, $filters);
     }
 
@@ -80,15 +79,14 @@ class NotificationService
      */
     public function getResourceFromNotification(array $notification): array
     {
-        if (!isset($notification['resource'])) {
+        if (! isset($notification['resource'])) {
             throw new \InvalidArgumentException('Notification must contain a resource field');
         }
 
         $resource = ltrim($notification['resource'], '/');
-        
+
         return ApiRequest::get($resource)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -102,7 +100,7 @@ class NotificationService
     public function processNotification(array $notification): array
     {
         $resourceData = $this->getResourceFromNotification($notification);
-        
+
         return [
             'notification' => $notification,
             'resource_data' => $resourceData,
@@ -118,13 +116,13 @@ class NotificationService
     public function validateNotification(array $notification): bool
     {
         $required = ['resource', 'user_id', 'topic', 'application_id'];
-        
+
         foreach ($required as $field) {
-            if (!isset($notification[$field])) {
+            if (! isset($notification[$field])) {
                 return false;
             }
         }
-        
+
         return true;
     }
 
@@ -172,6 +170,7 @@ class NotificationService
     public function hasNotificationAction(array $notification, string $action): bool
     {
         $actions = $this->getNotificationActions($notification);
+
         return $actions ? in_array($action, $actions) : false;
     }
 

--- a/src/Services/OrderService.php
+++ b/src/Services/OrderService.php
@@ -2,7 +2,6 @@
 
 namespace Zdearo\Meli\Services;
 
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -21,8 +20,7 @@ class OrderService
     public function get(int $orderId): array
     {
         return ApiRequest::get("orders/{$orderId}")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -37,11 +35,11 @@ class OrderService
     {
         $request = ApiRequest::get('orders/search');
 
-        if (!empty($filters)) {
+        if (! empty($filters)) {
             $request->withQuery($filters);
         }
 
-        return $request->send()->json();
+        return $request->send();
     }
 
     /**
@@ -56,6 +54,7 @@ class OrderService
     public function getBySeller(int $sellerId, array $filters = []): array
     {
         $filters['seller'] = $sellerId;
+
         return $this->search($filters);
     }
 
@@ -71,6 +70,7 @@ class OrderService
     public function getByBuyer(int $buyerId, array $filters = []): array
     {
         $filters['buyer'] = $buyerId;
+
         return $this->search($filters);
     }
 
@@ -86,6 +86,7 @@ class OrderService
     public function getByStatus(string $status, array $filters = []): array
     {
         $filters['order.status'] = $status;
+
         return $this->search($filters);
     }
 
@@ -104,6 +105,7 @@ class OrderService
     {
         $filters["order.date_{$dateField}.from"] = $dateFrom;
         $filters["order.date_{$dateField}.to"] = $dateTo;
+
         return $this->search($filters);
     }
 
@@ -121,8 +123,9 @@ class OrderService
         if (is_array($tags)) {
             $tags = implode(',', $tags);
         }
-        
+
         $filters['tags'] = $tags;
+
         return $this->search($filters);
     }
 
@@ -140,8 +143,9 @@ class OrderService
         if (is_array($tags)) {
             $tags = implode(',', $tags);
         }
-        
+
         $filters['tags.not'] = $tags;
+
         return $this->search($filters);
     }
 
@@ -169,8 +173,7 @@ class OrderService
     public function getProductInfo(int $orderId): array
     {
         return ApiRequest::get("orders/{$orderId}/product")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -184,8 +187,7 @@ class OrderService
     public function getDiscounts(int $orderId): array
     {
         return ApiRequest::get("orders/{$orderId}/discounts")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -204,7 +206,7 @@ class OrderService
         $filters['limit'] = $limit;
         $filters['offset'] = $offset;
         $filters['sort'] = $sort;
-        
+
         return $this->search($filters);
     }
 

--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -2,7 +2,6 @@
 
 namespace Zdearo\Meli\Services;
 
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -21,8 +20,7 @@ class PaymentService
     public function get(int $paymentId): array
     {
         return ApiRequest::get("collections/{$paymentId}")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -37,8 +35,7 @@ class PaymentService
     {
         return ApiRequest::get('payments/search')
             ->withQuery($filters)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -79,6 +76,7 @@ class PaymentService
     public function getByStatus(string $status, array $filters = []): array
     {
         $filters['status'] = $status;
+
         return $this->search($filters);
     }
 
@@ -162,6 +160,7 @@ class PaymentService
     {
         $filters["date_{$dateField}.from"] = $dateFrom;
         $filters["date_{$dateField}.to"] = $dateTo;
+
         return $this->search($filters);
     }
 
@@ -177,6 +176,7 @@ class PaymentService
     public function getByPaymentMethod(string $paymentMethodId, array $filters = []): array
     {
         $filters['payment_method_id'] = $paymentMethodId;
+
         return $this->search($filters);
     }
 
@@ -192,6 +192,7 @@ class PaymentService
     public function getByCollector(int $collectorId, array $filters = []): array
     {
         $filters['collector_id'] = $collectorId;
+
         return $this->search($filters);
     }
 
@@ -207,6 +208,7 @@ class PaymentService
     public function getByPayer(int $payerId, array $filters = []): array
     {
         $filters['payer_id'] = $payerId;
+
         return $this->search($filters);
     }
 
@@ -224,7 +226,7 @@ class PaymentService
     {
         $filters['limit'] = $limit;
         $filters['offset'] = $offset;
-        
+
         return $this->search($filters);
     }
 
@@ -252,6 +254,7 @@ class PaymentService
     public function getCreditCardPayments(array $filters = []): array
     {
         $filters['payment_type'] = 'credit_card';
+
         return $this->search($filters);
     }
 
@@ -266,6 +269,7 @@ class PaymentService
     public function getDebitCardPayments(array $filters = []): array
     {
         $filters['payment_type'] = 'debit_card';
+
         return $this->search($filters);
     }
 
@@ -280,6 +284,7 @@ class PaymentService
     public function getBankTransferPayments(array $filters = []): array
     {
         $filters['payment_type'] = 'bank_transfer';
+
         return $this->search($filters);
     }
 
@@ -294,6 +299,7 @@ class PaymentService
     public function getTicketPayments(array $filters = []): array
     {
         $filters['payment_type'] = 'ticket';
+
         return $this->search($filters);
     }
 
@@ -308,6 +314,7 @@ class PaymentService
     public function getRefundAccountMoneyPayments(array $filters = []): array
     {
         $filters['tags'] = 'refund_account_money';
+
         return $this->search($filters);
     }
 }

--- a/src/Services/ProductService.php
+++ b/src/Services/ProductService.php
@@ -2,7 +2,6 @@
 
 namespace Zdearo\Meli\Services;
 
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -22,8 +21,7 @@ class ProductService
     {
         return ApiRequest::post('items')
             ->withBody($productData)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -37,8 +35,7 @@ class ProductService
     public function get(string $itemId): array
     {
         return ApiRequest::get("items/{$itemId}")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -54,8 +51,7 @@ class ProductService
     {
         return ApiRequest::put("items/{$itemId}")
             ->withBody($updateData)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -71,7 +67,6 @@ class ProductService
     {
         return ApiRequest::put("items/{$itemId}")
             ->withBody(['status' => $status])
-            ->send()
-            ->json();
+            ->send();
     }
 }

--- a/src/Services/QuestionService.php
+++ b/src/Services/QuestionService.php
@@ -3,7 +3,6 @@
 namespace Zdearo\Meli\Services;
 
 use Illuminate\Http\Client\Response;
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -22,11 +21,10 @@ class QuestionService
     public function search(array $filters = []): array
     {
         $filters['api_version'] = 4;
-        
+
         return ApiRequest::get('questions/search')
             ->withQuery($filters)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -41,6 +39,7 @@ class QuestionService
     public function getBySeller(int $sellerId, array $filters = []): array
     {
         $filters['seller_id'] = $sellerId;
+
         return $this->search($filters);
     }
 
@@ -56,6 +55,7 @@ class QuestionService
     public function getByItem(string $itemId, array $filters = []): array
     {
         $filters['item'] = $itemId;
+
         return $this->search($filters);
     }
 
@@ -73,6 +73,7 @@ class QuestionService
     {
         $filters['from'] = $userId;
         $filters['item'] = $itemId;
+
         return $this->search($filters);
     }
 
@@ -88,8 +89,7 @@ class QuestionService
     {
         return ApiRequest::get("questions/{$questionId}")
             ->withQuery(['api_version' => 4])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -108,8 +108,7 @@ class QuestionService
                 'item_id' => $itemId,
                 'text' => $text,
             ])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -128,8 +127,7 @@ class QuestionService
                 'question_id' => $questionId,
                 'text' => $text,
             ])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -158,6 +156,7 @@ class QuestionService
     public function getUnansweredBySeller(int $sellerId, array $filters = []): array
     {
         $filters['status'] = 'UNANSWERED';
+
         return $this->getBySeller($sellerId, $filters);
     }
 
@@ -173,6 +172,7 @@ class QuestionService
     public function getAnsweredBySeller(int $sellerId, array $filters = []): array
     {
         $filters['status'] = 'ANSWERED';
+
         return $this->getBySeller($sellerId, $filters);
     }
 
@@ -188,6 +188,7 @@ class QuestionService
     public function getByStatus(string $status, array $filters = []): array
     {
         $filters['status'] = $status;
+
         return $this->search($filters);
     }
 
@@ -203,11 +204,11 @@ class QuestionService
      */
     public function searchSorted(array $filters = [], array $sortFields = [], string $sortType = 'ASC'): array
     {
-        if (!empty($sortFields)) {
+        if (! empty($sortFields)) {
             $filters['sort_fields'] = implode(',', $sortFields);
             $filters['sort_types'] = $sortType;
         }
-        
+
         return $this->search($filters);
     }
 
@@ -225,7 +226,7 @@ class QuestionService
     {
         $filters['limit'] = $limit;
         $filters['offset'] = $offset;
-        
+
         return $this->search($filters);
     }
 
@@ -240,8 +241,7 @@ class QuestionService
     public function getResponseTime(int $userId): array
     {
         return ApiRequest::get("users/{$userId}/questions/response_time")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -256,8 +256,7 @@ class QuestionService
     {
         return ApiRequest::post('my/questions/hidden')
             ->withBody(['question_ids' => $questionIds])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**

--- a/src/Services/SearchItemService.php
+++ b/src/Services/SearchItemService.php
@@ -3,7 +3,6 @@
 namespace Zdearo\Meli\Services;
 
 use Zdearo\Meli\Enums\MarketplaceEnum;
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -39,8 +38,7 @@ class SearchItemService
     {
         return ApiRequest::get($this->siteUri)
             ->withQuery(['q' => $value, 'offset' => $offset])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -55,8 +53,7 @@ class SearchItemService
     {
         return ApiRequest::get($this->siteUri)
             ->withQuery(['category' => $categoryId])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -71,8 +68,7 @@ class SearchItemService
     {
         return ApiRequest::get($this->siteUri)
             ->withQuery(['nickname' => $nickname])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -94,8 +90,7 @@ class SearchItemService
 
         return ApiRequest::get($this->siteUri)
             ->withQuery($query)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -113,8 +108,7 @@ class SearchItemService
 
         return ApiRequest::get("users/{$userId}/items/search")
             ->withQuery($query)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -136,8 +130,7 @@ class SearchItemService
 
         return ApiRequest::get('items')
             ->withQuery($query)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -152,7 +145,6 @@ class SearchItemService
     {
         return ApiRequest::get('users')
             ->withQuery(['ids' => implode(',', $userIds)])
-            ->send()
-            ->json();
+            ->send();
     }
 }

--- a/src/Services/UserService.php
+++ b/src/Services/UserService.php
@@ -21,8 +21,7 @@ class UserService
     public function get(int $userId): array
     {
         return ApiRequest::get("users/{$userId}")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -35,8 +34,7 @@ class UserService
     public function me(): array
     {
         return ApiRequest::get('users/me')
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -52,8 +50,7 @@ class UserService
     {
         return ApiRequest::put("users/{$userId}")
             ->withBody($userData)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -67,8 +64,7 @@ class UserService
     public function getAddresses(int $userId): array
     {
         return ApiRequest::get("users/{$userId}/addresses")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -82,8 +78,7 @@ class UserService
     public function getAcceptedPaymentMethods(int $userId): array
     {
         return ApiRequest::get("users/{$userId}/accepted_payment_methods")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -97,8 +92,7 @@ class UserService
     public function getBrands(int $userId): array
     {
         return ApiRequest::get("users/{$userId}/brands")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -119,7 +113,7 @@ class UserService
             $request->withQuery(['category_id' => $categoryId]);
         }
 
-        return $request->send()->json();
+        return $request->send();
     }
 
     /**
@@ -141,7 +135,7 @@ class UserService
             $request->withQuery(['category_id' => $categoryId]);
         }
 
-        return $request->send()->json();
+        return $request->send();
     }
 
     /**
@@ -155,8 +149,7 @@ class UserService
     public function getClassifiedsPromotionPacks(int $userId): array
     {
         return ApiRequest::get("users/{$userId}/classifieds_promotion_packs")
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -172,8 +165,7 @@ class UserService
     {
         return ApiRequest::post("users/{$userId}/classifieds_promotion_packs")
             ->withBody($packData)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -190,8 +182,7 @@ class UserService
     {
         return ApiRequest::get("users/{$userId}/classifieds_promotion_packs/{$listingType}")
             ->withQuery(['categoryId' => $categoryId])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**

--- a/src/Services/VisitsService.php
+++ b/src/Services/VisitsService.php
@@ -2,7 +2,6 @@
 
 namespace Zdearo\Meli\Services;
 
-use Zdearo\Meli\Exceptions\ApiException;
 use Zdearo\Meli\Support\ApiRequest;
 
 /**
@@ -27,8 +26,7 @@ class VisitsService
                 'date_from' => $dateFrom,
                 'date_to' => $dateTo,
             ])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -43,8 +41,7 @@ class VisitsService
     {
         return ApiRequest::get('visits/items')
             ->withQuery(['ids' => $itemId])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -65,8 +62,7 @@ class VisitsService
                 'date_from' => $dateFrom,
                 'date_to' => $dateTo,
             ])
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -93,8 +89,7 @@ class VisitsService
 
         return ApiRequest::get("users/{$userId}/items_visits/time_window")
             ->withQuery($params)
-            ->send()
-            ->json();
+            ->send();
     }
 
     /**
@@ -121,7 +116,6 @@ class VisitsService
 
         return ApiRequest::get("items/{$itemId}/visits/time_window")
             ->withQuery($params)
-            ->send()
-            ->json();
+            ->send();
     }
 }


### PR DESCRIPTION
Eliminate unnecessary `json()` method calls after `send()` in service methods. Ensure consistency across all service classes and improve flexibility for handling raw API responses.