### PR TITLE
chore(dependencies): require PHP 8.3 and simplify region enum resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/http": "^9.0|^10.0|^11.0|^12.0"
     },

--- a/src/MeliServiceProvider.php
+++ b/src/MeliServiceProvider.php
@@ -23,7 +23,7 @@ class MeliServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(SearchItemService::class, function ($app) {
-            $region = MarketplaceEnum::from(config('meli.region', 'BRASIL'));
+            $region = MarketplaceEnum::{config('meli.region')};
             return new SearchItemService($region);
         });
     }


### PR DESCRIPTION
This pull request updates the minimum PHP version requirement and refactors how the region is selected when binding the `SearchItemService`. These changes help ensure compatibility with newer PHP features and streamline the region configuration logic.

**Dependency and compatibility updates:**

* Updated the minimum required PHP version in `composer.json` from `^8.1` to `^8.3`, ensuring the package uses the latest stable PHP features and security improvements.

**Code logic improvements:**

* Refactored the region selection in the `SearchItemService` binding within `src/MeliServiceProvider.php` to use dynamic enum access (`MarketplaceEnum::{config('meli.region')}`) instead of the `from` method, simplifying the code and reducing default value handling.